### PR TITLE
Move library(ggrough) to first chunk in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,6 +26,7 @@ library(dplyr)
 
 ```{r cars, fig.height=5, fig.width=12}
 library(ggplot2)
+library(ggrough)
 count(mtcars, carb) %>%
   ggplot(aes(carb, n)) +
   geom_col() + 
@@ -35,7 +36,6 @@ p
 ```
 
 ```{r eval=FALSE, eval=FALSE, echo=TRUE}
-library(ggrough)
 options <- list(
   Background=list(roughness=8),
   GeomCol=list(fill_style="zigzag", angle_noise=0.5, fill_weight=2))

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ using the excellent javascript [`roughjs`](http://roughjs.com) library.
 
 ``` r
 library(ggplot2)
+library(ggrough)
 count(mtcars, carb) %>%
   ggplot(aes(carb, n)) +
   geom_col() + 
@@ -24,7 +25,6 @@ p
 ![](README_files/figure-gfm/cars-1.png)<!-- -->
 
 ``` r
-library(ggrough)
 options <- list(
   Background=list(roughness=8),
   GeomCol=list(fill_style="zigzag", angle_noise=0.5, fill_weight=2))


### PR DESCRIPTION
Moved the call to attach ggrough to the first code chunk, since you need it for the pipe. This avoids throwing:

```r
#> Error in count(mtcars, carb) %>% ggplot(aes(carb, n)) : 
#>  could not find function "%>%"
```

Love this package! 💖